### PR TITLE
Add Codecstring definition to draft-ietf-moq-loc

### DIFF
--- a/draft-ietf-moq-loc.md
+++ b/draft-ietf-moq-loc.md
@@ -232,6 +232,14 @@ to microseconds since Unix epoch.
 * Length: Omitted (ID is even)
 * Value: vi64 (1-9 bytes)
 
+#### Codecstring
+
+* Name: Codecstring
+* Description: Codec string as defined by WebCodecs Codec Registry
+* ID: 0x11
+* Length: Varies
+* Value: Varies
+
 ### Video Properties
 
 #### Video Config {#vconfig}


### PR DESCRIPTION
Added Codecstring section with details on codec strings. That will allow to use LOC without catalog dependency